### PR TITLE
Check if 'userIP' is available in request

### DIFF
--- a/src/base/Gateway.php
+++ b/src/base/Gateway.php
@@ -500,7 +500,7 @@ abstract class Gateway extends BaseGateway
             'currency' => $transaction->paymentCurrency,
             'transactionId' => $transaction->hash,
             'description' => Craft::t('commerce', 'Order').' #'.$transaction->orderId,
-            'clientIp' => Craft::$app->getRequest()->userIP,
+            'clientIp' => (property_exists(Craft::$app->getRequest(), 'userIP')? Craft::$app->getRequest()->userIP : ''),
             'transactionReference' => $transaction->hash,
             'returnUrl' => UrlHelper::actionUrl('commerce/payments/complete-payment', $params),
             'cancelUrl' => UrlHelper::siteUrl($transaction->order->cancelUrl),


### PR DESCRIPTION
When using console for executing payment requests (for example for webhooks added to the queue) there is no userIP available.
A simple check fixes the problem.

as proposed in [issue 9](https://github.com/craftcms/commerce-omnipay/issues/9): 