### PR TITLE
Always add transaction code to request

### DIFF
--- a/src/base/Gateway.php
+++ b/src/base/Gateway.php
@@ -502,6 +502,7 @@ abstract class Gateway extends BaseGateway
             'description' => Craft::t('commerce', 'Order').' #'.$transaction->orderId,
             'clientIp' => Craft::$app->getRequest()->userIP ?? '',
             'transactionReference' => $transaction->hash,
+            'code' => $transaction->code,
             'returnUrl' => UrlHelper::actionUrl('commerce/payments/complete-payment', $params),
             'cancelUrl' => UrlHelper::siteUrl($transaction->order->cancelUrl),
         ];


### PR DESCRIPTION
### Description

Always adds the available transaction code to the request. I have a custom gateway that relies on it and right now, I have to fetch the code from the db by transaction hash or id, while it could be immediately available in the request.

