### PR TITLE
Omnipay itemBag price should be converted to payment currency

### DIFF
--- a/src/base/Gateway.php
+++ b/src/base/Gateway.php
@@ -680,7 +680,10 @@ abstract class Gateway extends BaseGateway
 
         /** @var LineItem $item */
         foreach ($order->lineItems as $item) {
-            $price = Currency::round($item->salePrice);
+            $price = Currency::round(
+                Commerce::getInstance()->getPaymentCurrencies()->convertCurrency($item->salePrice, $order->currency, $order->paymentCurrency),
+                Commerce::getInstance()->getPaymentCurrencies()->getPaymentCurrencyByIso($order->paymentCurrency)
+            );
             // Can not accept zero amount items. See item (4) here:
             // https://developer.paypal.com/docs/classic/express-checkout/integration-guide/ECCustomizing/#setting-order-details-on-the-paypal-review-page
 

--- a/src/base/Gateway.php
+++ b/src/base/Gateway.php
@@ -710,8 +710,11 @@ abstract class Gateway extends BaseGateway
 
         /** @var OrderAdjustment $adjustment */
         foreach ($order->adjustments as $adjustment) {
-            $price = Currency::round($adjustment->amount);
-
+            $price = Currency::round(
+                Commerce::getInstance()->getPaymentCurrencies()->convertCurrency($adjustment->amount, $order->currency, $order->paymentCurrency),
+                Commerce::getInstance()->getPaymentCurrencies()->getPaymentCurrencyByIso($order->paymentCurrency)
+            );
+            
             // Do not include the 'included' adjustments, and do not send zero value items
             // See item (4) https://developer.paypal.com/docs/classic/express-checkout/integration-guide/ECCustomizing/#setting-order-details-on-the-paypal-review-page
             if (($adjustment->included == 0 || $adjustment->included == false) && $price !== 0) {


### PR DESCRIPTION
### Description
Fixes bug when trying purchase items in a secondary currency, in stead of the primary currency


### Related issues
https://github.com/craftcms/commerce-omnipay/issues/22
